### PR TITLE
test(no-release): add local live JMAP E2E

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -381,6 +381,7 @@ $RECYCLE.BIN/
 /coverage
 /playwright-report
 /test-results
+/test-results-live
 
 # build
 /dist

--- a/README.md
+++ b/README.md
@@ -76,3 +76,20 @@ Check out the (soon to be updated) [wiki](https://github.com/ajyey/masked-email-
 See [End-to-End Testing Improvements](docs/e2e-testing-implementation.md) for
 local commands, test architecture, CI behavior, browser strategies, and the
 manual Chrome and Firefox release checks.
+
+To run the local-only extension suite against a real Fastmail account, provide
+an API token with masked email JMAP access:
+
+```bash
+JMAP_TOKEN='your-fastmail-api-token' yarn test:e2e:live
+```
+
+To watch the live test run in Chromium:
+
+```bash
+JMAP_TOKEN='your-fastmail-api-token' E2E_HEADED=1 yarn test:e2e:live
+```
+
+This test creates, updates, and deletes a uniquely marked masked email. It is
+blocked in CI and attempts to clean up its records even when a test fails. See
+the E2E guide above for headed mode, artifact, and cleanup details.

--- a/docs/e2e-testing-implementation.md
+++ b/docs/e2e-testing-implementation.md
@@ -37,6 +37,29 @@ The normal E2E command builds Chrome first. It intentionally remains separate
 from `yarn check` because browser installation and execution are a distinct CI
 concern.
 
+## Local Live Fastmail Test
+
+An opt-in local suite exercises the production extension against the real
+Fastmail JMAP service. It is separate from normal E2E discovery and is blocked
+when the `CI` environment variable is present.
+
+```bash
+JMAP_TOKEN='your-fastmail-api-token' yarn test:e2e:live
+```
+
+The token must grant access to Fastmail's masked email JMAP capability.
+Set `E2E_HEADED=1` as well to watch the browser. The test authenticates through
+the popup, creates a uniquely marked masked email, edits it, disables and
+enables it, favorites it, soft-deletes it, permanently deletes it, and logs
+out. Server state is verified through direct JMAP requests after each mutation.
+
+The suite removes stale records carrying the dedicated live-test description
+marker before it starts and performs best-effort cleanup in `finally`. Do not
+send mail to an address while the test is running because Fastmail may then
+prevent permanent deletion. Playwright traces and screenshots follow the
+normal local policy and can contain the supplied token or authenticated state;
+keep those artifacts on the local machine.
+
 ## Test Architecture
 
 ### Installed Extension Harness

--- a/docs/e2e-testing-implementation.md
+++ b/docs/e2e-testing-implementation.md
@@ -50,8 +50,9 @@ JMAP_TOKEN='your-fastmail-api-token' yarn test:e2e:live
 The token must grant access to Fastmail's masked email JMAP capability.
 Set `E2E_HEADED=1` as well to watch the browser. The test authenticates through
 the popup, creates a uniquely marked masked email, edits it, disables and
-enables it, favorites it, soft-deletes it, permanently deletes it, and logs
-out. Server state is verified through direct JMAP requests after each mutation.
+enables it, verifies it through search, favorites it, soft-deletes it,
+permanently deletes it, and logs out. Server state is verified through direct
+JMAP requests after each mutation.
 
 The suite removes stale records carrying the dedicated live-test description
 marker before it starts and performs best-effort cleanup in `finally`. Do not

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -46,7 +46,7 @@ export default tseslint.config(
     }
   },
   {
-    files: ['tests/e2e/fixtures/test.ts'],
+    files: ['tests/e2e/fixtures/test.ts', 'tests/live/fixtures/test.ts'],
     rules: { 'no-empty-pattern': 'off' }
   },
   prettier

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "test:e2e:run": "playwright test",
     "test:e2e:headed": "E2E_HEADED=1 playwright test",
     "test:e2e:debug": "E2E_HEADED=1 PWDEBUG=1 playwright test",
+    "test:e2e:live": "E2E_LIVE_JMAP=1 run-s build:production:chrome test:e2e:run",
     "test:watch": "vitest",
     "typecheck": "tsc --noEmit",
     "dev": "run-p dev:chrome dev:firefox",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,14 +1,24 @@
 import { defineConfig } from '@playwright/test';
 
+const isLiveJmapRun = process.env.E2E_LIVE_JMAP === '1';
+
+if (isLiveJmapRun && process.env.CI) {
+  throw new Error('Live JMAP tests are local-only and cannot run in CI.');
+}
+if (isLiveJmapRun && !process.env.JMAP_TOKEN) {
+  throw new Error('JMAP_TOKEN is required to run the live JMAP tests.');
+}
+
 export default defineConfig({
-  testDir: './tests/e2e',
+  testDir: isLiveJmapRun ? './tests/live' : './tests/e2e',
   testMatch: '**/*.e2e.ts',
   fullyParallel: false,
   workers: 1,
-  retries: process.env.CI ? 2 : 0,
-  timeout: 30_000,
-  expect: { timeout: 5_000 },
+  retries: isLiveJmapRun ? 0 : process.env.CI ? 2 : 0,
+  timeout: isLiveJmapRun ? 120_000 : 30_000,
+  expect: { timeout: isLiveJmapRun ? 15_000 : 5_000 },
   reporter: process.env.CI ? [['line'], ['html', { open: 'never' }]] : 'list',
+  outputDir: isLiveJmapRun ? 'test-results-live' : 'test-results',
   use: {
     trace: 'retain-on-failure',
     screenshot: 'only-on-failure',

--- a/tests/live/fixtures/fastmail.ts
+++ b/tests/live/fixtures/fastmail.ts
@@ -18,6 +18,8 @@ interface JmapResponse<T> {
   methodResponses: [string, T, string][];
 }
 
+// Keep verification independent from the client used by the extension so the
+// test can detect client integration regressions and still clean up failures.
 export class LiveFastmail {
   private constructor(
     private readonly token: string,
@@ -103,6 +105,7 @@ export class LiveFastmail {
     const body = (await response.json()) as JmapResponse<T>;
     const methodResponse = body.methodResponses?.[0];
     if (!methodResponse) throw new Error('Fastmail returned no JMAP response.');
+    // JMAP method errors are returned inside successful HTTP responses.
     if (methodResponse[0] === 'error') {
       const error = methodResponse[1] as {
         description?: string;

--- a/tests/live/fixtures/fastmail.ts
+++ b/tests/live/fixtures/fastmail.ts
@@ -1,0 +1,117 @@
+const coreCapability = 'urn:ietf:params:jmap:core';
+const maskedEmailCapability = 'https://www.fastmail.com/dev/maskedemail';
+
+export interface LiveMaskedEmail {
+  id: string;
+  email: string;
+  state: 'enabled' | 'disabled' | 'pending' | 'deleted';
+  forDomain: string;
+  description: string;
+}
+
+interface Session {
+  apiUrl: string;
+  primaryAccounts: Record<string, string>;
+}
+
+interface JmapResponse<T> {
+  methodResponses: [string, T, string][];
+}
+
+export class LiveFastmail {
+  private constructor(
+    private readonly token: string,
+    private readonly apiUrl: string,
+    private readonly accountId: string
+  ) {}
+
+  static async connect(token: string) {
+    const response = await fetch('https://api.fastmail.com/jmap/session', {
+      headers: { Authorization: `Bearer ${token}` }
+    });
+    if (!response.ok) {
+      throw new Error(`Fastmail session request failed: ${response.status}`);
+    }
+
+    const session = (await response.json()) as Session;
+    const accountId = session.primaryAccounts[maskedEmailCapability];
+    if (!session.apiUrl || !accountId) {
+      throw new Error('Fastmail session is missing masked email access.');
+    }
+    return new LiveFastmail(token, session.apiUrl, accountId);
+  }
+
+  async getAllEmails() {
+    const response = await this.call<{ list?: LiveMaskedEmail[] }>(
+      'MaskedEmail/get',
+      { accountId: this.accountId }
+    );
+    return response.list ?? [];
+  }
+
+  async updateEmail(
+    id: string,
+    update: Partial<
+      Pick<LiveMaskedEmail, 'description' | 'forDomain' | 'state'>
+    >
+  ) {
+    const response = await this.call<{
+      notUpdated?: Record<string, { description?: string; type: string }>;
+    }>('MaskedEmail/set', {
+      accountId: this.accountId,
+      update: { [id]: update }
+    });
+    const failure = response.notUpdated?.[id];
+    if (failure) {
+      throw new Error(
+        `Fastmail update failed: ${failure.description ?? failure.type}`
+      );
+    }
+  }
+
+  async permanentlyDeleteEmail(id: string) {
+    const response = await this.call<{
+      notDestroyed?: Record<string, { description?: string; type: string }>;
+    }>('MaskedEmail/set', {
+      accountId: this.accountId,
+      destroy: [id]
+    });
+    const failure = response.notDestroyed?.[id];
+    if (failure) {
+      throw new Error(
+        `Fastmail deletion failed: ${failure.description ?? failure.type}`
+      );
+    }
+  }
+
+  private async call<T>(method: string, arguments_: Record<string, unknown>) {
+    const response = await fetch(this.apiUrl, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${this.token}`,
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({
+        using: [coreCapability, maskedEmailCapability],
+        methodCalls: [[method, arguments_, 'live-test']]
+      })
+    });
+    if (!response.ok) {
+      throw new Error(`Fastmail JMAP request failed: ${response.status}`);
+    }
+
+    const body = (await response.json()) as JmapResponse<T>;
+    const methodResponse = body.methodResponses?.[0];
+    if (!methodResponse) throw new Error('Fastmail returned no JMAP response.');
+    if (methodResponse[0] === 'error') {
+      const error = methodResponse[1] as {
+        description?: string;
+        type?: string;
+      };
+      throw new Error(
+        `Fastmail JMAP error: ${error.description ?? error.type ?? 'unknown'}`
+      );
+    }
+    return methodResponse[1];
+  }
+}

--- a/tests/live/fixtures/test.ts
+++ b/tests/live/fixtures/test.ts
@@ -1,0 +1,32 @@
+import { test as base, expect, type Page } from '@playwright/test';
+
+import { ExtensionHarness } from '../../e2e/fixtures/extension';
+import { PopupPage } from '../../e2e/pages/popup';
+
+interface LiveFixtures {
+  extension: ExtensionHarness;
+  popup: Page;
+  popupPage: PopupPage;
+}
+
+export const test = base.extend<LiveFixtures>({
+  extension: async ({}, provide) => {
+    const extension = await ExtensionHarness.launch();
+    try {
+      await provide(extension);
+      extension.assertNoUnexpectedErrors();
+    } finally {
+      await extension.close();
+    }
+  },
+  popup: async ({ extension }, provide) => {
+    const popup = await extension.openPopup();
+    await provide(popup);
+    await popup.close();
+  },
+  popupPage: async ({ popup }, provide) => {
+    await provide(new PopupPage(popup));
+  }
+});
+
+export { expect };

--- a/tests/live/masked-email-lifecycle.e2e.ts
+++ b/tests/live/masked-email-lifecycle.e2e.ts
@@ -13,6 +13,7 @@ async function findEmail(
 async function removeEmail(fastmail: LiveFastmail, id: string) {
   const email = await findEmail(fastmail, (candidate) => candidate.id === id);
   if (!email) return;
+  // Fastmail only permits permanent destruction after an address is deleted.
   if (email.state !== 'deleted') {
     await fastmail.updateEmail(id, { state: 'deleted' });
   }
@@ -22,6 +23,7 @@ async function removeEmail(fastmail: LiveFastmail, id: string) {
 async function removeStaleLiveEmails(fastmail: LiveFastmail) {
   const emails = await fastmail.getAllEmails();
   for (const email of emails) {
+    // The reserved marker scopes cleanup to records created by this suite.
     if (email.description.startsWith(liveMarker)) {
       await removeEmail(fastmail, email.id);
     }
@@ -73,6 +75,21 @@ test('manages a masked email against live Fastmail JMAP', async ({
       popupPage.emailOption(createdEmail.email, 'enabled')
     ).toHaveAttribute('aria-selected', 'true');
 
+    // Searching the full address can fuzzy-match every address sharing its
+    // domain, so use the generated local part to target this record.
+    const addressQuery = createdEmail.email.split('@')[0];
+    await popupPage.search(addressQuery);
+    await expect(
+      popup.getByRole('textbox', { name: 'Search masked emails' })
+    ).toHaveValue(addressQuery);
+    await expect(
+      popupPage.emailOption(createdEmail.email, 'enabled')
+    ).toBeVisible();
+    await expect(
+      popupPage.emailOption(createdEmail.email, 'enabled')
+    ).toHaveAttribute('aria-selected', 'true');
+    await popupPage.clearSearch();
+
     await popupPage.editSelectedEmail({
       domain: updatedDomain,
       description: updatedDescription
@@ -123,11 +140,13 @@ test('manages a masked email against live Fastmail JMAP', async ({
     await expect
       .poll(async () => findEmail(fastmail, (email) => email.id === createdId))
       .toBeUndefined();
+    // Successful deletion prevents the finally block from repeating it.
     createdId = undefined;
 
     await popupPage.logout();
     await popupPage.expectLogin();
   } finally {
+    // Clean up the server record if any assertion fails after creation.
     if (createdId) await removeEmail(fastmail, createdId);
   }
 });

--- a/tests/live/masked-email-lifecycle.e2e.ts
+++ b/tests/live/masked-email-lifecycle.e2e.ts
@@ -1,0 +1,133 @@
+import { expect, test } from './fixtures/test';
+import { LiveFastmail, type LiveMaskedEmail } from './fixtures/fastmail';
+
+const liveMarker = '[Masked Email Manager live test]';
+
+async function findEmail(
+  fastmail: LiveFastmail,
+  predicate: (email: LiveMaskedEmail) => boolean
+) {
+  return (await fastmail.getAllEmails()).find(predicate);
+}
+
+async function removeEmail(fastmail: LiveFastmail, id: string) {
+  const email = await findEmail(fastmail, (candidate) => candidate.id === id);
+  if (!email) return;
+  if (email.state !== 'deleted') {
+    await fastmail.updateEmail(id, { state: 'deleted' });
+  }
+  await fastmail.permanentlyDeleteEmail(id);
+}
+
+async function removeStaleLiveEmails(fastmail: LiveFastmail) {
+  const emails = await fastmail.getAllEmails();
+  for (const email of emails) {
+    if (email.description.startsWith(liveMarker)) {
+      await removeEmail(fastmail, email.id);
+    }
+  }
+}
+
+test('manages a masked email against live Fastmail JMAP', async ({
+  extension,
+  popup,
+  popupPage
+}) => {
+  const token = process.env.JMAP_TOKEN;
+  if (!token) throw new Error('JMAP_TOKEN is required for live tests.');
+
+  const runId = `${Date.now()}-${process.pid}`;
+  const description = `${liveMarker} ${runId}`;
+  const updatedDescription = `${description} updated`;
+  const domain = `https://live-${runId}.invalid`;
+  const updatedDomain = `https://updated-live-${runId}.invalid`;
+  const fastmail = await LiveFastmail.connect(token);
+  let createdId: string | undefined;
+
+  await removeStaleLiveEmails(fastmail);
+
+  try {
+    await popupPage.login(token);
+    await popupPage.expectHome();
+
+    await popupPage.createEmail({ domain, description });
+    await expect
+      .poll(async () =>
+        Boolean(
+          await findEmail(
+            fastmail,
+            (email) => email.description === description
+          )
+        )
+      )
+      .toBe(true);
+
+    const createdEmail = await findEmail(
+      fastmail,
+      (email) => email.description === description
+    );
+    if (!createdEmail) throw new Error('Unable to find the live test email.');
+    createdId = createdEmail.id;
+
+    await expect(
+      popupPage.emailOption(createdEmail.email, 'enabled')
+    ).toHaveAttribute('aria-selected', 'true');
+
+    await popupPage.editSelectedEmail({
+      domain: updatedDomain,
+      description: updatedDescription
+    });
+    await expect
+      .poll(async () => findEmail(fastmail, (email) => email.id === createdId))
+      .toMatchObject({
+        description: updatedDescription,
+        forDomain: updatedDomain
+      });
+
+    await popupPage.setSelectedEmailEnabled(false);
+    await expect
+      .poll(
+        async () =>
+          (await findEmail(fastmail, (email) => email.id === createdId))?.state
+      )
+      .toBe('disabled');
+
+    await popupPage.selectFilter('Disabled');
+    await popupPage.selectEmail(createdEmail.email, 'disabled');
+    await popupPage.setSelectedEmailEnabled(true);
+    await expect
+      .poll(
+        async () =>
+          (await findEmail(fastmail, (email) => email.id === createdId))?.state
+      )
+      .toBe('enabled');
+
+    await popupPage.selectFilter('Enabled');
+    await popupPage.selectEmail(createdEmail.email, 'enabled');
+    await popupPage.favoriteSelectedEmail();
+    await expect
+      .poll(async () => (await extension.getStorage(popup)).favorite_emails)
+      .toContain(createdId);
+
+    await popupPage.softDeleteSelectedEmail();
+    await expect
+      .poll(
+        async () =>
+          (await findEmail(fastmail, (email) => email.id === createdId))?.state
+      )
+      .toBe('deleted');
+
+    await popupPage.selectFilter('Deleted');
+    await popupPage.selectEmail(createdEmail.email, 'deleted');
+    await popupPage.permanentlyDeleteSelectedEmail();
+    await expect
+      .poll(async () => findEmail(fastmail, (email) => email.id === createdId))
+      .toBeUndefined();
+    createdId = undefined;
+
+    await popupPage.logout();
+    await popupPage.expectLogin();
+  } finally {
+    if (createdId) await removeEmail(fastmail, createdId);
+  }
+});


### PR DESCRIPTION
## Summary

- Add an opt-in Playwright suite that runs the production Chrome extension against the real Fastmail JMAP service.
- Exercise a complete masked-email lifecycle and search flow through the popup while independently verifying server state through direct JMAP requests.
- Keep live tests strictly local and separate from deterministic mocked E2E tests and CI.
- Document token requirements, headed execution, data mutation, cleanup, and artifact handling.

## Motivation

The mocked E2E suite provides deterministic regression coverage, but it cannot detect changes in Fastmail authentication, JMAP capabilities, response behavior, or production network integration. This live suite provides a manual pre-release confidence check without introducing external-service instability or credentials into CI.

## Live Scenario

The test loads the built extension into Playwright Chromium and performs the following workflow through the real popup:

1. Authenticate using `JMAP_TOKEN`.
2. Load the account's masked emails.
3. Create a uniquely marked enabled masked email.
4. Verify the created record through direct JMAP retrieval.
5. Search by the generated address's local part and verify that the created email remains visible and selected.
6. Edit its domain and description and verify the server mutation.
7. Disable and re-enable the address.
8. Favorite it and verify synchronized extension storage.
9. Soft-delete the address.
10. Permanently delete it and verify server removal.
11. Log out and return to the login view.

## Isolation And Cleanup

- Live tests are discovered only when `E2E_LIVE_JMAP=1` is set by the dedicated package script.
- Playwright throws immediately if a live run is attempted with `CI` set.
- `JMAP_TOKEN` is required and must provide Fastmail masked-email JMAP access.
- Test records use a unique timestamp/process marker and the reserved `[Masked Email Manager live test]` description prefix.
- Stale records carrying that marker are removed before execution.
- The active test record is deleted in `finally` when a scenario fails after creation.
- Live artifacts are isolated under ignored `test-results-live/`; traces and screenshots may contain authenticated state and must remain local.
- The existing mocked E2E suite and its CI behavior are unchanged.

## Implementation

- Add a local Playwright fixture that reuses the installed-extension harness and popup page object without installing the Fastmail route mock.
- Add a minimal raw JMAP helper for session discovery, masked-email retrieval, update verification, and cleanup.
- Switch Playwright test discovery, timeouts, retries, and output paths only for explicit live runs.
- Add README and detailed E2E guide examples for headless and headed execution.

## Usage

```bash
JMAP_TOKEN='your-fastmail-api-token' yarn test:e2e:live
```

Headed mode:

```bash
JMAP_TOKEN='your-fastmail-api-token' E2E_HEADED=1 yarn test:e2e:live
```

Do not send mail to the generated address during the run because Fastmail may then prevent permanent deletion.

## Validation

- `yarn check` passed: lint, typecheck, 33 unit tests, Chrome build, Firefox build, and artifact verification.
- `yarn test:e2e:run` passed: 42 deterministic extension E2E tests.
- Live discovery selects exactly one test when `E2E_LIVE_JMAP=1` and a placeholder token are provided.
- Missing-token guard verified.
- CI execution guard verified.
- The authenticated headed live scenario passed locally, including search visibility and selection assertions.
